### PR TITLE
Fix for ambiguity error thrown by certain compilers.

### DIFF
--- a/Dehiscent.java
+++ b/Dehiscent.java
@@ -153,30 +153,30 @@ public class Dehiscent {
    */
   public static String controlsToString() {
     return IO.formatBanner(IO.BOX_WIDTH) +
-            IO.formatColumns(IO.BOX_WIDTH, "COMMAND", "HOTKEY", "EFFECT") +
+            IO.formatColumns(IO.BOX_WIDTH, true, true, "COMMAND", "HOTKEY", "EFFECT") +
             IO.formatBanner(IO.BOX_WIDTH) +
-            IO.formatColumns(IO.BOX_WIDTH, "go north", "w", "Go north") +
-            IO.formatColumns(IO.BOX_WIDTH, "go south", "a", "Go south") +
-            IO.formatColumns(IO.BOX_WIDTH, "go west", "s", "Go west") +
-            IO.formatColumns(IO.BOX_WIDTH, "go east", "d", "Go east") +
-            IO.formatColumns(IO.BOX_WIDTH, "explore", "x", "Explore the area") +
+            IO.formatColumns(IO.BOX_WIDTH, true, true, "go north", "w", "Go north") +
+            IO.formatColumns(IO.BOX_WIDTH, true, true, "go south", "a", "Go south") +
+            IO.formatColumns(IO.BOX_WIDTH, true, true, "go west", "s", "Go west") +
+            IO.formatColumns(IO.BOX_WIDTH, true, true, "go east", "d", "Go east") +
+            IO.formatColumns(IO.BOX_WIDTH, true, true, "explore", "x", "Explore the area") +
             IO.formatBanner(IO.BOX_WIDTH) +
-            IO.formatColumns(IO.BOX_WIDTH, "use <item>", "u", "Use an item") +
-            IO.formatColumns(IO.BOX_WIDTH, "equip <item>", "e", "Equip an item") +
-            IO.formatColumns(IO.BOX_WIDTH, "unequip <item>", "ue", "Unequip an item") +
-            IO.formatColumns(IO.BOX_WIDTH, "inspect <item>", "i", "Unequip an item") +
+            IO.formatColumns(IO.BOX_WIDTH, true, true, "use <item>", "u", "Use an item") +
+            IO.formatColumns(IO.BOX_WIDTH, true, true, "equip <item>", "e", "Equip an item") +
+            IO.formatColumns(IO.BOX_WIDTH, true, true, "unequip <item>", "ue", "Unequip an item") +
+            IO.formatColumns(IO.BOX_WIDTH, true, true, "inspect <item>", "i", "Unequip an item") +
             IO.formatBanner(IO.BOX_WIDTH) +
-            IO.formatColumns(IO.BOX_WIDTH, "view <options>", "v", "View summary of all") +
-            IO.formatColumns(IO.BOX_WIDTH, "  map", "", "Check the map") +
-            IO.formatColumns(IO.BOX_WIDTH, "  inv", "", "View inventory") +
-            IO.formatColumns(IO.BOX_WIDTH, "  equip", "", "See all equipped") +
-            IO.formatColumns(IO.BOX_WIDTH, "  current", "", "Inspect all equipped") +
-            IO.formatColumns(IO.BOX_WIDTH, "  position", "", "Check position") +
-            IO.formatColumns(IO.BOX_WIDTH, "  stats", "", "View stats") +
-            IO.formatColumns(IO.BOX_WIDTH, "  base", "", "View base stats") +
-            IO.formatColumns(IO.BOX_WIDTH, "  controls", "", "See this menu") +
+            IO.formatColumns(IO.BOX_WIDTH, true, true, "view <options>", "v", "View summary of all") +
+            IO.formatColumns(IO.BOX_WIDTH, true, true, "  map", "", "Check the map") +
+            IO.formatColumns(IO.BOX_WIDTH, true, true, "  inv", "", "View inventory") +
+            IO.formatColumns(IO.BOX_WIDTH, true, true, "  equip", "", "See all equipped") +
+            IO.formatColumns(IO.BOX_WIDTH, true, true, "  current", "", "Inspect all equipped") +
+            IO.formatColumns(IO.BOX_WIDTH, true, true, "  position", "", "Check position") +
+            IO.formatColumns(IO.BOX_WIDTH, true, true, "  stats", "", "View stats") +
+            IO.formatColumns(IO.BOX_WIDTH, true, true, "  base", "", "View base stats") +
+            IO.formatColumns(IO.BOX_WIDTH, true, true, "  controls", "", "See this menu") +
             IO.formatBanner(IO.BOX_WIDTH) +
-            IO.formatColumns(IO.BOX_WIDTH, "[0-9]", "", "Select menu options") +
+            IO.formatColumns(IO.BOX_WIDTH, true, true, "[0-9]", "", "Select menu options") +
             IO.formatBanner(IO.BOX_WIDTH);
   }
 }

--- a/README.md
+++ b/README.md
@@ -81,9 +81,10 @@ All contributions should generally follow the version control workflow below. Th
 7. Stay up to date and pull in other peoples' changes which have made it into upstream, this will help avoid future conflicts
 
   ```
+  git remote add upstream https://github.com/open-holloway-makers/dehiscent-rpg.git
   git fetch upstream
   git checkout master
-  git merge upstream master
+  git rebase upstream/master
   ```
 
 8. When you're happy with the contributions you've added to your fork, submit a pull request on GitHub and wait for your additions to be accepted into upstream!

--- a/core/CombatResolver.java
+++ b/core/CombatResolver.java
@@ -129,7 +129,7 @@ public class CombatResolver {
       if (!player.getEquipSlots().get(hands.get(i)).isFree()) {
         holding = player.getEquipSlots().get(hands.get(i)).getItem().getName();
       }
-      IO.print(IO.formatColumns(IO.BOX_WIDTH, i + ": " + hand, holding));
+      IO.print(IO.formatColumns(IO.BOX_WIDTH, true, true, i + ": " + hand, holding));
     }
     IO.println(IO.formatBanner(IO.BOX_WIDTH));
   }

--- a/core/IO.java
+++ b/core/IO.java
@@ -194,20 +194,6 @@ public class IO {
    * arguments provided.
    *
    * @param maxLineLength the width of the line.
-   * @param arguments the arguments (columns) to display.
-   * @return a formatted string containing the arguments as columns.
-   */
-  public static String formatColumns(int maxLineLength, Object... arguments) {
-    return formatColumns(maxLineLength, true, true, arguments);
-  }
-
-  /**
-   * Formats a line of values as if they are columns in a
-   * table. The width of the table will fit to the maxLineLength
-   * provided and the number of columns is equal to the object
-   * arguments provided.
-   *
-   * @param maxLineLength the width of the line.
    * @param alignLeft align the content of the middle columns to the left.
    * @param bordered print a border either side of the row.
    * @param arguments the arguments (columns) to display.

--- a/core/Player.java
+++ b/core/Player.java
@@ -423,7 +423,7 @@ public abstract class Player {
       IntStream.range(0, possibleEquipSlots.size())
               .forEachOrdered(i ->
                       IO.print(IO.formatColumns(IO.BOX_WIDTH,
-                              i + ": " + possibleEquipSlots.get(i),
+                              true, true, i + ": " + possibleEquipSlots.get(i),
                               (getEquipSlots().get(possibleEquipSlots.get(i)).isFree()) ?
                                       "(empty)" :
                                       getEquipSlots()

--- a/core/TransactionResolver.java
+++ b/core/TransactionResolver.java
@@ -147,7 +147,7 @@ public class TransactionResolver {
    */
   private static String affairsToString(Player player, Merchant merchant) {
     return "\b" + IO.formatBanner(IO.BOX_WIDTH) +
-            IO.formatColumns(IO.BOX_WIDTH, "You : " + player.getGold(),
+            IO.formatColumns(IO.BOX_WIDTH, true, true, "You : " + player.getGold(),
                     merchant.getGold() + " : " + merchant.getName()) +
             IO.formatBanner(IO.BOX_WIDTH);
   }

--- a/items/Item.java
+++ b/items/Item.java
@@ -63,10 +63,10 @@ public class Item {
     final int len = IO.BOX_WIDTH;
     return "\n" +
             IO.formatBanner(len) +
-            IO.formatColumns(len, getName(), getValue() + " gold") +
+            IO.formatColumns(len, true, true, getName(), getValue() + " gold") +
             IO.formatBanner(len) +
-            IO.formatColumns(len, "Equip to:", (isEquippable()) ? getSlotType().getValue().toString() : "n/a") +
-            IO.formatColumns(len, "Modifier:", (getModifiers().size() > 0) ? modifiersToString() : "n/a") +
+            IO.formatColumns(len, true, true, "Equip to:", (isEquippable()) ? getSlotType().getValue().toString() : "n/a") +
+            IO.formatColumns(len, true, true, "Modifier:", (getModifiers().size() > 0) ? modifiersToString() : "n/a") +
             IO.formatAsBox(getLoreText(), len, true);
   }
 

--- a/items/Weapon.java
+++ b/items/Weapon.java
@@ -65,18 +65,18 @@ public class Weapon extends Item {
     final int len = IO.BOX_WIDTH;
     return "\n" +
             IO.formatBanner(len) +
-            IO.formatColumns(len, getName(), getValue() + " gold") +
+            IO.formatColumns(len, true, true, getName(), getValue() + " gold") +
             IO.formatBanner(len) +
-            IO.formatColumns(len, "Equip to:", (isEquippable()) ? getSlotType().getValue().toString() : "n/a") +
-            IO.formatColumns(len, "Modifier:", (getModifiers().size() > 0) ? modifiersToString() : "n/a") +
-            IO.formatColumns(len, "Physical Damage:", String.format("(%d)+%d", (int) getBaseDamage(),
+            IO.formatColumns(len, true, true, "Equip to:", (isEquippable()) ? getSlotType().getValue().toString() : "n/a") +
+            IO.formatColumns(len, true, true, "Modifier:", (getModifiers().size() > 0) ? modifiersToString() : "n/a") +
+            IO.formatColumns(len, true, true, "Physical Damage:", String.format("(%d)+%d", (int) getBaseDamage(),
                     (int) (getPhysicalAttackRating(player) - getBaseDamage()))) +
-            IO.formatColumns(len, "Magic Damage:", String.format("(%d)+%d", (int) getBaseMagicDamage(),
+            IO.formatColumns(len, true, true, "Magic Damage:", String.format("(%d)+%d", (int) getBaseMagicDamage(),
                     (int) (getMagicAttackRating(player) - getBaseMagicDamage()))) +
             IO.formatBanner(len) +
-            IO.formatColumns(len, "STR Scaling:", strengthScaling.getRating().toString()) +
-            IO.formatColumns(len, "DEX Scaling:", dexterityScaling.getRating().toString()) +
-            IO.formatColumns(len, "INT Scaling:", intelligenceScaling.getRating().toString()) +
+            IO.formatColumns(len, true, true, "STR Scaling:", strengthScaling.getRating().toString()) +
+            IO.formatColumns(len, true, true, "DEX Scaling:", dexterityScaling.getRating().toString()) +
+            IO.formatColumns(len, true, true, "INT Scaling:", intelligenceScaling.getRating().toString()) +
             IO.formatAsBox(getLoreText(), len, true);
   }
 }


### PR DESCRIPTION
Removed helper function for IO.formatColumns(int, Objects...) which was IO.formatColumns(int, boolean, boolean, Objects...) because some compilers threw an error because it couldn't find the 'most precise' function available (ambiguous functions) presumably because there is no subtype relationship between boolean and whatever the Objects might have been (particularly strings). Not sure what the exact details of the environment are that would throw this error. 
